### PR TITLE
Execute `database.init(Path("data/headless-rss.sqlite3"))` when starting FastAPI worker threads

### DIFF
--- a/src/api/nextcloud_news/app.py
+++ b/src/api/nextcloud_news/app.py
@@ -1,14 +1,20 @@
-from fastapi import FastAPI
+from contextlib import asynccontextmanager
 from pathlib import Path
+
+from fastapi import FastAPI
+
 from src import database
 
 from . import feed, folder, item
 
-app = FastAPI()
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    database.init(Path("data/headless-rss.sqlite3"))
+    yield
+
+
+app = FastAPI(lifespan=lifespan)
 app.include_router(feed.router)
 app.include_router(item.router)
 app.include_router(folder.router)
-
-@app.on_event("startup")
-async def startup_event():
-    database.init(Path("data/headless-rss.sqlite3"))

--- a/src/api/nextcloud_news/app.py
+++ b/src/api/nextcloud_news/app.py
@@ -1,4 +1,6 @@
 from fastapi import FastAPI
+from pathlib import Path
+from src import database
 
 from . import feed, folder, item
 
@@ -6,3 +8,7 @@ app = FastAPI()
 app.include_router(feed.router)
 app.include_router(item.router)
 app.include_router(folder.router)
+
+@app.on_event("startup")
+async def startup_event():
+    database.init(Path("data/headless-rss.sqlite3"))


### PR DESCRIPTION


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/paulstaab/headless-rss/pull/21?shareId=6c1c4c28-d967-4ede-ab69-a85df6a52aca).