### PR TITLE
Add a status endpoint under /status that returns HTTP 200 if the service is running

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -26,3 +26,9 @@ async def lifespan(app: FastAPI):
 app = FastAPI(lifespan=lifespan)
 
 app.include_router(nextcloud_router, prefix="/index.php/apps/news/api")
+
+
+@app.get("/status")
+async def status():
+    """Status endpoint to check if the service is running."""
+    return {"status": "ok"}

--- a/tests/api/test_app.py
+++ b/tests/api/test_app.py
@@ -12,3 +12,9 @@ def client() -> TestClient:
 def test_nextcloud_v1_2_access(client: TestClient) -> None:
     response = client.get("/index.php/apps/news/api/v1-2/version")
     assert response.status_code == 200
+
+
+def test_status_endpoint(client: TestClient) -> None:
+    response = client.get("/status")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}


### PR DESCRIPTION


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/paulstaab/headless-rss/pull/51?shareId=7ddf63a5-09dd-4238-bf92-923a5850b655).