### PR TITLE
Add cleanup after each feed update

### DIFF
--- a/src/article.py
+++ b/src/article.py
@@ -194,14 +194,10 @@ def clean_up_old_articles(feed_id: int, feed_articles) -> None:
     :param feed_id: The ID of the feed to clean up articles for.
     :param feed_articles: The articles from the feed.
     """
+    feed_article_guids = {article["id"] for article in feed_articles}
+    ninety_days_ago = int(time.time()) - 90 * 24 * 60 * 60
+    
     with database.get_session() as db:
-        feed = db.query(database.Feed).get(feed_id)
-        if not feed:
-            raise NoFeedError(f"Feed {feed_id} does not exist")
-
-        feed_article_guids = {article["id"] for article in feed_articles}
-
-        ninety_days_ago = int(time.time()) - 90 * 24 * 60 * 60
         articles_to_delete = (
             db.query(database.Article)
             .filter(database.Article.feed_id == feed_id)

--- a/src/article.py
+++ b/src/article.py
@@ -183,32 +183,3 @@ def mark_all_as_read(newest_item_id: int) -> int:
             item.last_modified = int(time.time())
         db.commit()
         return len(items)
-
-
-def clean_up_old_articles(feed_id: int, feed_articles) -> None:
-    """Clean up old articles from the database.
-
-    This function deletes articles that are not included in the feed anymore, read, not starred,
-    and have been last updated more than 90 days ago.
-
-    :param feed_id: The ID of the feed to clean up articles for.
-    :param feed_articles: The articles from the feed.
-    """
-    feed_article_guids = {article["id"] for article in feed_articles}
-    ninety_days_ago = int(time.time()) - 90 * 24 * 60 * 60
-    
-    with database.get_session() as db:
-        articles_to_delete = (
-            db.query(database.Article)
-            .filter(database.Article.feed_id == feed_id)
-            .filter(database.Article.guid.notin_(feed_article_guids))
-            .filter(database.Article.unread == False)  # noqa: E712
-            .filter(database.Article.starred == False)  # noqa: E712
-            .filter(database.Article.last_modified < ninety_days_ago)
-            .all()
-        )
-
-        for article in articles_to_delete:
-            db.delete(article)
-
-        db.commit()

--- a/src/article.py
+++ b/src/article.py
@@ -183,3 +183,36 @@ def mark_all_as_read(newest_item_id: int) -> int:
             item.last_modified = int(time.time())
         db.commit()
         return len(items)
+
+
+def clean_up_old_articles(feed_id: int, feed_articles) -> None:
+    """Clean up old articles from the database.
+
+    This function deletes articles that are not included in the feed anymore, read, not starred,
+    and have been last updated more than 90 days ago.
+
+    :param feed_id: The ID of the feed to clean up articles for.
+    :param feed_articles: The articles from the feed.
+    """
+    with database.get_session() as db:
+        feed = db.query(database.Feed).get(feed_id)
+        if not feed:
+            raise NoFeedError(f"Feed {feed_id} does not exist")
+
+        feed_article_guids = {article["id"] for article in feed_articles}
+
+        ninety_days_ago = int(time.time()) - 90 * 24 * 60 * 60
+        articles_to_delete = (
+            db.query(database.Article)
+            .filter(database.Article.feed_id == feed_id)
+            .filter(database.Article.guid.notin_(feed_article_guids))
+            .filter(database.Article.unread == False)  # noqa: E712
+            .filter(database.Article.starred == False)  # noqa: E712
+            .filter(database.Article.last_modified < ninety_days_ago)
+            .all()
+        )
+
+        for article in articles_to_delete:
+            db.delete(article)
+
+        db.commit()

--- a/src/feed.py
+++ b/src/feed.py
@@ -338,10 +338,10 @@ def clean_up_old_articles(feed_id: int, feed_articles) -> None:
         articles_to_delete = (
             db.query(database.Article)
             .filter(database.Article.feed_id == feed_id)
-            .filter(database.Article.guid.notin_(feed_article_guids))
+            .filter(database.Article.last_modified < ninety_days_ago)
             .filter(database.Article.unread == False)  # noqa: E712
             .filter(database.Article.starred == False)  # noqa: E712
-            .filter(database.Article.last_modified < ninety_days_ago)
+            .filter(database.Article.guid.notin_(feed_article_guids))
             .all()
         )
 

--- a/src/feed.py
+++ b/src/feed.py
@@ -112,6 +112,8 @@ def update(feed_id: int, max_articles: int = 50) -> None:
         feed.next_update_time = _calculate_next_update_time(feed_id)
         db.commit()
 
+    clean_up_old_articles(feed_id, parsed_feed.entries)
+
 
 def _create_article(article, feed_id: int) -> database.Article:
     """Create a new article in the database.
@@ -320,3 +322,36 @@ def rename(feed_id: int, new_title: str) -> None:
         feed.title = new_title
         db.commit()
         db.refresh(feed)
+
+
+def clean_up_old_articles(feed_id: int, feed_articles) -> None:
+    """Clean up old articles from the database.
+
+    This function deletes articles that are not included in the feed anymore, read, not starred,
+    and have been last updated more than 90 days ago.
+
+    :param feed_id: The ID of the feed to clean up articles for.
+    :param feed_articles: The articles from the feed.
+    """
+    with database.get_session() as db:
+        feed = db.query(database.Feed).get(feed_id)
+        if not feed:
+            raise NoFeedError(f"Feed {feed_id} does not exist")
+
+        feed_article_guids = {article["id"] for article in feed_articles}
+
+        ninety_days_ago = now() - 90 * one_day
+        articles_to_delete = (
+            db.query(database.Article)
+            .filter(database.Article.feed_id == feed_id)
+            .filter(database.Article.guid.notin_(feed_article_guids))
+            .filter(database.Article.unread == False)  # noqa: E712
+            .filter(database.Article.starred == False)  # noqa: E712
+            .filter(database.Article.last_modified < ninety_days_ago)
+            .all()
+        )
+
+        for article in articles_to_delete:
+            db.delete(article)
+
+        db.commit()


### PR DESCRIPTION
Add a clean-up process after each feed update to delete old articles from the database.

* Add `clean_up_old_articles` function in `src/feed.py` to delete articles not in the feed, read, not starred, and older than 90 days.
* Call `clean_up_old_articles` at the end of the `update` function in `src/feed.py`.
* Modify the `update` function in `src/feed.py` to get the feed articles from `parsed_feed.entries` instead of parsing the feed again.
* Add `clean_up_old_articles` function in `src/article.py` to delete articles based on the specified criteria.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/paulstaab/headless-rss/pull/67?shareId=0a517816-4a0d-421f-89ef-f1edaf14a4ee).