### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python


### PR DESCRIPTION
Potential fix for [https://github.com/paulstaab/headless-rss/security/code-scanning/2](https://github.com/paulstaab/headless-rss/security/code-scanning/2)

To fix the issue, add a `permissions` block to the `test` job. This block should specify the minimal permissions required for the job to function. Based on the job's steps, it primarily needs to read the repository contents to run tests and migrations. Therefore, the `contents: read` permission is sufficient.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
