### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python


### PR DESCRIPTION
Potential fix for [https://github.com/paulstaab/headless-rss/security/code-scanning/1](https://github.com/paulstaab/headless-rss/security/code-scanning/1)

To fix the issue, add a `permissions` block to the `lint` job in the workflow file `.github/workflows/ci.yml`. The `lint` job only needs read access to the repository contents, so the permissions should be set to `contents: read`. This change ensures that the job does not inherit unnecessary write permissions from the repository.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
