### PR TITLE
Potential fix for code scanning alert no. 13: Uncontrolled allocation size

### DIFF
--- a/docs/api-nextcloud-v1-2-contract.md
+++ b/docs/api-nextcloud-v1-2-contract.md
@@ -85,10 +85,12 @@ Contract for the implemented Nextcloud News compatible API v1.2.
 - `PUT /items/{feedId}/{guidHash}/star`
 - `PUT /items/star/multiple`
   - Request: `{"items":[{"feedId":<int>,"guidHash":"<string>"}, ...]}`
+  - Error: `400` if request contains more than 10,000 items
   - Error: `404` if any item unresolved
 - `PUT /items/{feedId}/{guidHash}/unstar`
 - `PUT /items/unstar/multiple`
   - Request: same shape as star/multiple
+  - Error: `400` if request contains more than 10,000 items
   - Error: `404` if any item unresolved
 - `PUT /items/read`
   - Request: `{"newestItemId": <int>}`

--- a/docs/api-nextcloud-v1-2-test-cases.md
+++ b/docs/api-nextcloud-v1-2-test-cases.md
@@ -40,6 +40,7 @@ Test cases for implemented Nextcloud News API v1.2 behavior.
 - Verify read/unread bulk endpoints with v1.2 payload shape (`items`).
 - Verify star/unstar single-item endpoints using `feedId/guidHash` route format.
 - Verify star/unstar bulk endpoints with guid-hash payload objects.
+- Verify v1.2 guid-hash bulk star/unstar rejects payloads larger than 10,000 items with `400`.
 - Verify mark-all-read endpoint behavior.
 - Verify state-changing operations update `lastModified`.
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -85,6 +85,7 @@ Implementation progress is tracked separately in `docs/implementation-status.md`
 - `ITEM-007`: Single and bulk star/unstar operations shall be supported.
 - `ITEM-008`: Read/star state changes shall update `last_modified`.
 - `ITEM-009`: Mark-as-read operations shall support boundary behavior using newest item ID for feed, folder, and global scopes.
+- `ITEM-010`: v1.2 GUID-hash bulk star/unstar requests shall reject payloads with more than 10,000 items using `400 Bad Request`.
 
 ### Content Extraction And Summarization
 - `CNT-001`: If feed metadata does not provide a thumbnail, the system shall extract the first image URL from HTML content when available.

--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -217,6 +217,7 @@ Source: `src/api.rs`
 | TC-RUST-085 | Rust mocked newsletter journey | Run the Rust CLI credential command and update command with a test-only mocked IMAP mailbox file. | Newsletter feed/items are created through the full subprocess path without requiring a real mailbox. |
 | TC-RUST-090 | Rust newsletter parser falls back to single mode | Normalize an LLM newsletter parse result that provides fewer than two distinct usable item URLs. | Result is coerced to `single`, uses cleaned fallback content, and supplies a concise summary. |
 | TC-RUST-091 | Rust newsletter parser deduplicates multi-item links | Normalize an LLM newsletter parse result with duplicate item URLs and at least two distinct links. | Duplicate URLs are discarded and the result remains `multi` only when at least two distinct links remain. |
+| TC-RUST-092 | Rust v1-2 guid-star-multiple request limit | Call `PUT /index.php/apps/news/api/v1-2/items/star/multiple` with more than 10,000 guid-hash objects. | Returns `400` with `{"detail":"too many items in request: 10001 (max 10000)"}`. |
 
 ### Rust Newsletter Processing Test Cases
 Source: `src/email.rs`

--- a/src/api/errors.rs
+++ b/src/api/errors.rs
@@ -32,6 +32,14 @@ pub(super) fn ssrf_error<E: std::fmt::Display>(error: E) -> ApiError {
     )
 }
 
+/// Returns a bad-request error with a caller-provided detail message.
+pub(super) fn bad_request_error<E: std::fmt::Display>(error: E) -> ApiError {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(serde_json::json!({ "detail": error.to_string() })),
+    )
+}
+
 /// Returns a not-found error for a missing feed identifier.
 pub(super) fn feed_not_found_with_id(feed_id: i64) -> ApiError {
     (

--- a/src/api/items.rs
+++ b/src/api/items.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use sqlx::{FromRow, QueryBuilder, Sqlite, SqlitePool};
 
 use super::AppState;
-use super::errors::{ApiResult, internal_error, item_not_found};
+use super::errors::{ApiResult, bad_request_error, internal_error, item_not_found};
 use super::folders::MarkAllItemsReadIn;
 
 // Maximum number of GUID items allowed in a single request to prevent
@@ -507,10 +507,7 @@ async fn query_items(pool: &SqlitePool, input: QueryItemsInput) -> ApiResult<Vec
         }
         3 => {}
         _ => {
-            return Err((
-                StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({ "detail": "Invalid item selection type" })),
-            ));
+            return Err(bad_request_error("Invalid item selection type"));
         }
     }
 
@@ -576,13 +573,9 @@ async fn resolve_guid_item_ids(pool: &SqlitePool, items: Vec<GuidItemIn>) -> Api
     let len = items.len();
     // Guard against unbounded allocations and excessive work from user-controlled input.
     if len > MAX_GUID_ITEMS_PER_REQUEST {
-        return Err(internal_error(
-            format!(
-                "too many items in request: {} (max {})",
-                len, MAX_GUID_ITEMS_PER_REQUEST
-            )
-            .into(),
-        ));
+        return Err(bad_request_error(format!(
+            "too many items in request: {len} (max {MAX_GUID_ITEMS_PER_REQUEST})"
+        )));
     }
 
     let mut ids = Vec::with_capacity(len);

--- a/src/api/tests/items.rs
+++ b/src/api/tests/items.rs
@@ -701,6 +701,34 @@ async fn v1_2_mark_multiple_guid_items_as_starred_updates_last_modified() {
 }
 
 #[tokio::test]
+async fn v1_2_mark_multiple_guid_items_rejects_oversized_payload() {
+    let item = serde_json::json!({"feedId":10,"guidHash":"guid-hash-1"});
+    let payload = serde_json::json!({"items": vec![item; 10_001]}).to_string();
+
+    let response = app(state(setup_pool().await))
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri("/index.php/apps/news/api/v1-2/items/star/multiple")
+                .header("content-type", "application/json")
+                .body(Body::from(payload))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), 400);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let parsed: Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(
+        parsed["detail"],
+        "too many items in request: 10001 (max 10000)"
+    );
+}
+
+#[tokio::test]
 async fn v1_3_mark_multiple_items_as_unread_updates_last_modified() {
     let pool = setup_pool().await;
     sqlx::query("UPDATE article SET unread = 0, last_modified = 200 WHERE id = 100")


### PR DESCRIPTION
Potential fix for [https://github.com/paulstaab/headless-rss/security/code-scanning/13](https://github.com/paulstaab/headless-rss/security/code-scanning/13)

In general, to fix uncontrolled allocation size from user input, enforce an upper bound on the size derived from the input before using it for allocation, and reject or truncate requests that exceed that bound. Here, the problematic value is `items.len()` in `resolve_guid_item_ids`, which is under the client’s control through `Json<GuidItemsIn>`.

The best fix without changing behavior for reasonable inputs is to introduce a constant limit on the maximum number of GUID items accepted in a single request (for example, a few thousand), check `items.len()` against this constant in `resolve_guid_item_ids`, and return an error (e.g., `StatusCode::BAD_REQUEST`) if the client sends more than that. This way, we keep the existing logic and API semantics for valid-sized requests, while preventing unbounded allocations and per-item DB queries. Concretely, in `src/api/items.rs`, near the other small helper definitions at the top (like `ItemsQueryParams` and its defaults), define a constant such as `MAX_GUID_ITEMS_PER_REQUEST: usize = 10_000;` (or whatever is appropriate for this API). Then, in `resolve_guid_item_ids`, before `Vec::with_capacity(items.len())`, check `if items.len() > MAX_GUID_ITEMS_PER_REQUEST { return Err(internal_error(anyhow_or_custom_error_here)); }`. Since we must not assume project-specific error types beyond what’s imported (`ApiResult`, `internal_error`, `item_not_found`), we can use `StatusCode::PAYLOAD_TOO_LARGE` or `StatusCode::BAD_REQUEST` via `internal_error` if it expects a generic error, or better, construct a simple error using `anyhow::anyhow!` if `anyhow` is already used; however we have not seen that, so the safest minimal change is to use `StatusCode::PAYLOAD_TOO_LARGE` wrapped via `internal_error` only if its signature supports that. Because we don’t see `internal_error`’s type here, an even less intrusive and type-safe approach is to avoid introducing new error types and instead simply cap the allocation: e.g., compute `let capped_len = items.len().min(MAX_GUID_ITEMS_PER_REQUEST);` and allocate using `Vec::with_capacity(capped_len)`, but then we must decide what to do with extra items. To avoid silently dropping items, it is better to reject the request.

Given we can’t see the custom error helpers, the most robust fix using only known standard types is to perform a manual check and, if exceeded, immediately return an `Err` produced via `internal_error(anyhow::anyhow!(...))`–but that would require adding `anyhow` if it isn’t already present. To avoid new dependencies, we can instead just guard the allocation by imposing a hard maximum capacity: compute a `let len = items.len(); if len > MAX_GUID_ITEMS_PER_REQUEST { return Err(internal_error("too many items in request".into())); }` where the string is converted into the project’s error type. This assumes `internal_error` can accept `String` or `&'static str`, which is typical for such helpers and does not add new imports. The changes are local to `resolve_guid_item_ids` and a new constant definition in `items.rs`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
